### PR TITLE
msi rebranding

### DIFF
--- a/createUiDefinition.json
+++ b/createUiDefinition.json
@@ -211,12 +211,12 @@
             "name": "sptype",
             "type": "Microsoft.Common.DropDown",
             "label": "Azure Authentication Type",
-            "defaultValue": "Auto(MI)",
-            "toolTip": "This will add credential for authenticating with Azure in Ansible. 'Auto' means that the service principal will be created by MI (Managed Identity). 'Manual' means that the service principal should be created by user and be filled in below.",
+            "defaultValue": "Auto(Managed Identities)",
+            "toolTip": "This will add credential for authenticating with Azure in Ansible. 'Auto' means that the service principal will be created by Managed Identities for VMs. 'Manual' means that the service principal should be created by user and be filled in below.",
             "constraints": {
               "allowedValues": [
                 {
-                  "label": "Auto(MI)",
+                  "label": "Auto(Managed Identities)",
                   "value": "mi"
                 },
                 {

--- a/createUiDefinition.json
+++ b/createUiDefinition.json
@@ -211,13 +211,13 @@
             "name": "sptype",
             "type": "Microsoft.Common.DropDown",
             "label": "Azure Authentication Type",
-            "defaultValue": "Auto(MSI)",
-            "toolTip": "This will add credential for authenticating with Azure in Ansible. 'Auto' means that the service principal will be created by MSI (Managed Service Identity). 'Manual' means that the service principal should be created by user and be filled in below.",
+            "defaultValue": "Auto(MI)",
+            "toolTip": "This will add credential for authenticating with Azure in Ansible. 'Auto' means that the service principal will be created by MI (Managed Identity). 'Manual' means that the service principal should be created by user and be filled in below.",
             "constraints": {
               "allowedValues": [
                 {
-                  "label": "Auto(MSI)",
-                  "value": "msi"
+                  "label": "Auto(MI)",
+                  "value": "mi"
                 },
                 {
                   "label": "Manual",

--- a/mainTemplate.json
+++ b/mainTemplate.json
@@ -114,9 +114,9 @@
       "type": "string"
     },
     "spType": {
-      "defaultValue": "msi",
+      "defaultValue": "mi",
       "metadata": {
-        "description": "The type of service principal injected into Ansible (can be 'msi' or 'manual')."
+        "description": "The type of service principal injected into Ansible (can be 'mi' or 'manual')."
       },
       "type": "string"
     },
@@ -329,7 +329,7 @@
       "dependsOn": [
         "[concat('Microsoft.Compute/virtualMachines/', parameters('vmName'))]"
       ],
-      "condition": "[equals(parameters('spType'), 'msi')]",
+      "condition": "[equals(parameters('spType'), 'mi')]",
       "properties": {
         "roleDefinitionId": "[concat(subscription().id, '/providers/Microsoft.Authorization/roleDefinitions/', 'b24988ac-6180-42a0-ab88-20f7382dd24c')]",
         "principalId": "[reference(concat(resourceId('Microsoft.Compute/virtualMachines/', parameters('vmName')),'/providers/Microsoft.ManagedIdentity/Identities/default'),'2015-08-31-PREVIEW').principalId]",

--- a/scripts/install_ansible_CentOS.sh
+++ b/scripts/install_ansible_CentOS.sh
@@ -7,7 +7,7 @@ Command
   $0
 Arguments
   --version|-v                        : Ansible version
-  --service_principal_type|-sp        : The type of service principal: MSI or manual.
+  --service_principal_type|-sp        : The type of service principal: MI or manual.
   --service_principal_id|-sid         : The service principal ID.
   --service_principal_secret|-ss      : The service principal secret.
   --subscription_id|-subid            : The subscription ID of the SP.
@@ -96,7 +96,7 @@ function set_azure_credentials {
         echo export AZURE_SECRET=${service_principal_secret} >> /etc/bashrc
         echo export AZURE_TENANT=${tenant_id} >> /etc/bashrc
 
-    elif [ "${service_principal_type}" == "msi" ]; then
+    elif [ "${service_principal_type}" == "mi" ]; then
         echo export ANSIBLE_AZURE_AUTH_SOURCE=msi >> /etc/profile
         echo export ANSIBLE_AZURE_AUTH_SOURCE=msi >> /etc/bashrc
     fi

--- a/scripts/install_ansible_Ubuntu.sh
+++ b/scripts/install_ansible_Ubuntu.sh
@@ -7,7 +7,7 @@ Command
   $0
 Arguments
   --version|-v                        : Ansible version
-  --service_principal_type|-sp        : The type of service principal: MSI or manual.
+  --service_principal_type|-sp        : The type of service principal: MI or manual.
   --service_principal_id|-sid         : The service principal ID.
   --service_principal_secret|-ss      : The service principal secret.
   --subscription_id|-subid            : The subscription ID of the SP.
@@ -96,7 +96,7 @@ function set_azure_credentials {
         echo export AZURE_SECRET=${service_principal_secret} >> /etc/bash.bashrc
         echo export AZURE_TENANT=${tenant_id} >> /etc/bash.bashrc
 
-    elif [ "${service_principal_type}" == "msi" ]; then
+    elif [ "${service_principal_type}" == "mi" ]; then
         echo export ANSIBLE_AZURE_AUTH_SOURCE=msi >> /etc/profile
         echo export ANSIBLE_AZURE_AUTH_SOURCE=msi >> /etc/bash.bashrc
     fi


### PR DESCRIPTION
This PR changes MSI to MI in the solution template.
It assumes that underlying Ansible will handle ANSIBLE_AZURE_AUTH_SOURCE=msi in appropriate way accordingly.